### PR TITLE
chore: resolve type mismatch for windows libs

### DIFF
--- a/miniupnpc/src/connecthostport.c
+++ b/miniupnpc/src/connecthostport.c
@@ -214,13 +214,13 @@ SOCKET connecthostport(const char * host, unsigned short port,
 		/* setting a 3 seconds timeout for the connect() call */
 		timeout.tv_sec = 3;
 		timeout.tv_usec = 0;
-		if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(struct timeval)) < 0)
+		if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(struct timeval)) < 0)
 		{
 			PRINT_SOCKET_ERROR("setsockopt");
 		}
 		timeout.tv_sec = 3;
 		timeout.tv_usec = 0;
-		if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(struct timeval)) < 0)
+		if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(struct timeval)) < 0)
 		{
 			PRINT_SOCKET_ERROR("setsockopt");
 		}


### PR DESCRIPTION
This PR resolves type mismatch issues in the nwaku repository, specifically addressing problems encountered during the Windows build process.